### PR TITLE
ci: add gradle build pipeline

### DIFF
--- a/.github/workflows/gradle-build.yaml
+++ b/.github/workflows/gradle-build.yaml
@@ -1,0 +1,96 @@
+name: Build stable ES8 modules
+
+on:
+  push:
+    tags:
+      - v.*
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.releaseVersion.outputs.releaseVersion }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm install conventional-changelog-conventionalcommits
+      - uses: codfish/semantic-release-action@v2
+        if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+        id: semantic
+        with:
+          repository_url: ${{ github.repositoryUrl }}
+          plugins: |
+            [
+              ['@semantic-release/commit-analyzer', {
+                "preset": "conventionalcommits",
+                "releaseRules": [
+                  {"type": "chore", "release": "patch"},
+                ]
+              }],
+              ['@semantic-release/release-notes-generator', {
+                "preset": "conventionalcommits",
+                "presetConfig": {
+                  "types": [
+                    {"type": "feat", "section": "Features"},
+                    {"type": "fix", "section": "Bug Fixes"},
+                    {"type": "chore", "hidden": true},
+                    {"type": "docs", "hidden": true},
+                    {"type": "style", "hidden": true},
+                    {"type": "refactor", "hidden": true},
+                    {"type": "perf", "hidden": true},
+                    {"type": "test", "hidden": true},
+                  ]
+                },
+              }],
+              ['@semantic-release/github', {
+                "successComment": false,
+                "failTitle": false
+              }]
+            ]
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: check version was generated
+        id: releaseVersion
+        run: |
+          if [[ -z "${{ steps.semantic.outputs.new_release_version }}" ]]; then
+            if [[ -z "$(git tag --points-at HEAD -l 'v*')" ]]; then
+              echo "No release version available"
+              exit 1
+            else
+            echo "releaseVersion=$(git tag --points-at HEAD -l 'v*')" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "releaseVersion=${{ steps.semantic.outputs.new_release_version }}" >> $GITHUB_OUTPUT
+          fi
+      - name: "Version Info:"
+        run: echo "${{ steps.releaseVersion.outputs.releaseVersion }}"
+  build:
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      matrix:
+        module:
+          - naive-lemmatizer
+          - naive-lemmatizer-less-prefixes
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'adopt'
+          cache: gradle
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: -PVersion=${{ needs.release.outputs.release }} bundlePlugin
+          build-root-directory: Sefaria-ElasticSearch-${{ matrix.module }}
+      - name: Upload artifact
+        run: |
+          cd Sefaria-ElasticSearch-${{ matrix.module }}/build/distributions
+          gh release upload ${{ needs.release.outputs.release }} '${{ matrix.module }}-${{ needs.release.outputs.release }}.zip' --clobber
+        env:
+         GH_TOKEN: ${{ github.token }}
+      - name: cleanup cache
+        run: rm -rf *
+        working-directory: Sefaria-ElasticSearch-${{ matrix.module }}/build/distributions


### PR DESCRIPTION
Add a pipeline to automatically build stable architecture plugin with gradle

Should trigger both on manually creating a release, or running the 'Build Stable Modules' workflow, which will create a new semantic release